### PR TITLE
Allow user to add custom headers to the uploader

### DIFF
--- a/app/src/main/java/eu/imouto/hupl/ui/EditHttpUploaderActivity.java
+++ b/app/src/main/java/eu/imouto/hupl/ui/EditHttpUploaderActivity.java
@@ -8,6 +8,7 @@ import android.preference.PreferenceActivity;
 import android.os.Bundle;
 import android.preference.PreferenceCategory;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.Toast;
 
 import org.json.JSONException;
@@ -35,7 +36,8 @@ public class EditHttpUploaderActivity extends PreferenceActivity
         "extraParams",
         "authUser",
         "authPass",
-        "disableChunkedTransfer"
+        "disableChunkedTransfer",
+        "headers"
     };
     private final static Map<String, String> jsonDefaults = initDefaults();
     private static Map<String, String> initDefaults()
@@ -131,7 +133,11 @@ public class EditHttpUploaderActivity extends PreferenceActivity
             if (pref instanceof EditTextPreference)
                 pref.setSummary(((EditTextPreference)pref).getText());
             pref.setOnPreferenceChangeListener(this);
+
         }
+
+        EditTextPreference headers = (EditTextPreference) findPreference("headers");
+        headers.getEditText().setSingleLine(false);
     }
 
     @Override

--- a/app/src/main/java/eu/imouto/hupl/upload/HttpUploader.java
+++ b/app/src/main/java/eu/imouto/hupl/upload/HttpUploader.java
@@ -123,7 +123,11 @@ public class HttpUploader extends Uploader
             }
 
             for (Map.Entry<String, String> entry: headers.entrySet()) {
-                connection.setRequestProperty(entry.getKey(), entry.getValue());
+                String value = entry.getValue()
+                                .replace("$NAME", file.fileName);
+
+                System.out.println("val " + entry.getKey() + " " + value);
+                connection.setRequestProperty(entry.getKey(), value);
             }
 
             //write multipart header

--- a/app/src/main/java/eu/imouto/hupl/upload/HttpUploader.java
+++ b/app/src/main/java/eu/imouto/hupl/upload/HttpUploader.java
@@ -126,7 +126,6 @@ public class HttpUploader extends Uploader
                 String value = entry.getValue()
                                 .replace("$NAME", file.fileName);
 
-                System.out.println("val " + entry.getKey() + " " + value);
                 connection.setRequestProperty(entry.getKey(), value);
             }
 

--- a/app/src/main/java/eu/imouto/hupl/upload/HttpUploader.java
+++ b/app/src/main/java/eu/imouto/hupl/upload/HttpUploader.java
@@ -30,6 +30,7 @@ public class HttpUploader extends Uploader
     public String targetUrl;
     public String authUser;
     public String authPass;
+    public Map<String, String> headers;
     public String fileParam;
     public String responseRegex;
     public boolean disableChunkedTransfer;
@@ -119,6 +120,10 @@ public class HttpUploader extends Uploader
             {
                 String auth = "Basic " + Base64.encodeToString((authUser+":"+authPass).getBytes(), Base64.NO_WRAP);
                 connection.setRequestProperty("Authorization", auth);
+            }
+
+            for (Map.Entry<String, String> entry: headers.entrySet()) {
+                connection.setRequestProperty(entry.getKey(), entry.getValue());
             }
 
             //write multipart header

--- a/app/src/main/java/eu/imouto/hupl/upload/UploaderFactory.java
+++ b/app/src/main/java/eu/imouto/hupl/upload/UploaderFactory.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import eu.imouto.hupl.data.FileToUpload;
 import eu.imouto.hupl.data.UploaderDB;
@@ -34,6 +35,7 @@ class UploaderFactory
             up.authPass = getStr(entry.json, "authPass");
             up.disableChunkedTransfer = getBool(entry.json, "disableChunkedTransfer", false);
             up.extraParams = getMap(entry.json, "extraParams");
+            up.headers = getHeaders(entry.json, "headers");
             return up;
         }
         return null;
@@ -78,5 +80,29 @@ class UploaderFactory
         catch (JSONException ex)
         {}
         return str;
+    }
+
+    private static Map<String, String> getHeaders(JSONObject obj, String name)
+    {
+        Map<String, String> headers = new HashMap<>();
+        String headersString = getStr(obj, "headers");
+        if (headersString == null || headersString.isBlank()) {
+            return headers;
+        }
+
+
+        String[] lines = headersString.split(Pattern.quote("\n"));
+        for (String line : lines) {
+            String[] lineSplit = line.split(Pattern.quote(":"));
+            if (lineSplit.length != 2) {
+                continue;
+            }
+
+            String key = lineSplit[0].trim();
+            String value = lineSplit[1].trim();
+            headers.put(key, value);
+        }
+
+        return headers;
     }
 }

--- a/app/src/main/java/eu/imouto/hupl/upload/UploaderFactory.java
+++ b/app/src/main/java/eu/imouto/hupl/upload/UploaderFactory.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.Iterator;
 
 import eu.imouto.hupl.data.FileToUpload;
 import eu.imouto.hupl.data.UploaderDB;
@@ -36,6 +37,7 @@ class UploaderFactory
             up.disableChunkedTransfer = getBool(entry.json, "disableChunkedTransfer", false);
             up.extraParams = getMap(entry.json, "extraParams");
             up.headers = getHeaders(entry.json, "headers");
+            up.extraParams = getMap(entry.json, "extraParams");
             return up;
         }
         return null;

--- a/app/src/main/java/eu/imouto/hupl/upload/UploaderFactory.java
+++ b/app/src/main/java/eu/imouto/hupl/upload/UploaderFactory.java
@@ -6,7 +6,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.Iterator;
@@ -35,8 +34,7 @@ class UploaderFactory
             up.authUser = getStr(entry.json, "authUser");
             up.authPass = getStr(entry.json, "authPass");
             up.disableChunkedTransfer = getBool(entry.json, "disableChunkedTransfer", false);
-            up.extraParams = getMap(entry.json, "extraParams");
-            up.headers = getHeaders(entry.json, "headers");
+            up.headers = getMap(entry.json, "headers");
             up.extraParams = getMap(entry.json, "extraParams");
             return up;
         }
@@ -82,29 +80,5 @@ class UploaderFactory
         catch (JSONException ex)
         {}
         return str;
-    }
-
-    private static Map<String, String> getHeaders(JSONObject obj, String name)
-    {
-        Map<String, String> headers = new HashMap<>();
-        String headersString = getStr(obj, "headers");
-        if (headersString == null || headersString.isBlank()) {
-            return headers;
-        }
-
-
-        String[] lines = headersString.split(Pattern.quote("\n"));
-        for (String line : lines) {
-            String[] lineSplit = line.split(Pattern.quote(":"));
-            if (lineSplit.length != 2) {
-                continue;
-            }
-
-            String key = lineSplit[0].trim();
-            String value = lineSplit[1].trim();
-            headers.put(key, value);
-        }
-
-        return headers;
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,5 +72,7 @@
     <string name="history_size">Verlauf Größe</string>
     <string name="history_size_summary">Maximale Anzahl an Einträgen im Upload-Verlauf</string>
     <string name="httpuploader_extra_params_title">Zusätzliche Parameter</string>
-    <string name="httpuploader_extra_params_summary">Sende zusätzliche Parameter (Formular Felder). \nEiner pro Zeile, in "param: value" Format.</string>
+    <string name="httpuploader_extra_params_summary">Sende zusätzliche Parameter (Formular Felder). \nEiner pro Zeile, in \"parameter: wert\" Format.</string>
+    <string name="httpuploader_headers_title">Header</string>
+    <string name="httpuploader_headers_summary">Zusätzliche HTTP Header. \nEiner pro Zeile, in \"key: value\" Format.\n\nVerfügbare Variablen: \n$NAME - Dateiname</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -73,4 +73,6 @@
     <string name="history_size_summary">アップロードしたファイルの履歴の最大保存件数</string>
     <string name="httpuploader_extra_params_title">追加パラメーター</string>
     <string name="httpuploader_extra_params_summary">パラメータ（フォームデータ）を追加。\n「param: hoge」という書式で一行一個。</string>
+    <string name="httpuploader_headers_title">ヘッダー</string>
+    <string name="httpuploader_headers_summary">HTTPのヘッダーを追加。\n「key: value」の書式で一行一個。\n\n利用可能な変数:\n$NAME - ファイル名</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="httpuploader_pass_title">Password</string>
     <string name="httpuploader_pass_summary">Note: Passwords are stored in plaintext</string>
     <string name="httpuploader_headers_title">Headers</string>
-    <string name="httpuploader_headers_summary">Each header in its own line, format KEY: VALUE.\n\nVariables: \n  $NAME - filename</string>
+    <string name="httpuploader_headers_summary">HTTP headers to add. \nOne per line, in \"key: value\" format.\n\nUsable variables: \n$NAME - filename</string>
 
     <string name="actionbar_title_uploaders">Edit Hosts</string>
     <string name="choose_uploader">Choose Uploader</string>
@@ -88,7 +88,7 @@
     <string name="httpuploader_disablechunkedtransfer_title">Disable Chunked Transfer</string>
     <string name="httpuploader_disablechunkedtransfer_summary">Only check this, if you\'re getting status code 411 from the server or have other troubles uploading.</string>
     <string name="httpuploader_extra_params_title">Extra Parameters</string>
-    <string name="httpuploader_extra_params_summary">Extra parameters (i.e. form fields) to send. \nOne per line, in "param: value" format.</string>
+    <string name="httpuploader_extra_params_summary">Extra parameters (i.e. form fields) to send. \nOne per line, in \"param: value\" format.</string>
 
     <!-- TODO: Remove or change this placeholder text -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,8 @@
     <string name="httpuploader_user_summary">Leave empty for no auth</string>
     <string name="httpuploader_pass_title">Password</string>
     <string name="httpuploader_pass_summary">Note: Passwords are stored in plaintext</string>
+    <string name="httpuploader_headers_title">Headers</string>
+    <string name="httpuploader_headers_summary">Each header in its own line, format KEY: VALUE</string>
 
     <string name="actionbar_title_uploaders">Edit Hosts</string>
     <string name="choose_uploader">Choose Uploader</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="httpuploader_pass_title">Password</string>
     <string name="httpuploader_pass_summary">Note: Passwords are stored in plaintext</string>
     <string name="httpuploader_headers_title">Headers</string>
-    <string name="httpuploader_headers_summary">Each header in its own line, format KEY: VALUE</string>
+    <string name="httpuploader_headers_summary">Each header in its own line, format KEY: VALUE.\n\nVariables: \n  $NAME - filename</string>
 
     <string name="actionbar_title_uploaders">Edit Hosts</string>
     <string name="choose_uploader">Choose Uploader</string>

--- a/app/src/main/res/xml/http_uploader_settings.xml
+++ b/app/src/main/res/xml/http_uploader_settings.xml
@@ -13,6 +13,10 @@
             android:title="@string/httpuploader_param_title"
             android:dialogMessage="@string/httpuploader_param_summary"
             android:key="fileParam"/>
+        <EditTextPreference
+            android:title="@string/httpuploader_headers_title"
+            android:dialogMessage="@string/httpuploader_headers_summary"
+            android:key="headers"/>
 
         <EditTextPreference
             android:title="@string/httpuploader_regex_title"

--- a/app/src/main/res/xml/http_uploader_settings.xml
+++ b/app/src/main/res/xml/http_uploader_settings.xml
@@ -13,14 +13,14 @@
             android:title="@string/httpuploader_param_title"
             android:dialogMessage="@string/httpuploader_param_summary"
             android:key="fileParam"/>
-        <EditTextPreference
-            android:title="@string/httpuploader_headers_title"
-            android:dialogMessage="@string/httpuploader_headers_summary"
-            android:key="headers"/>
 
         <EditTextPreference
             android:title="@string/httpuploader_regex_title"
             android:key="responseRegex"/>
+        <eu.imouto.hupl.ui.StringMapPreference
+            android:title="@string/httpuploader_headers_title"
+            android:dialogMessage="@string/httpuploader_headers_summary"
+            android:key="headers"/>
         <eu.imouto.hupl.ui.StringMapPreference
             android:title="@string/httpuploader_extra_params_title"
             android:dialogMessage="@string/httpuploader_extra_params_summary"


### PR DESCRIPTION
This feature allows user to send any arbitrary headers to the server, such as `Authorization` header. 

It also adds basic variable substitution (`$NAME` in any header value will be replaced with the filename).

Possible fix for the #20 