### PR TITLE
Allow uploading of plain text shares

### DIFF
--- a/app/src/main/java/eu/imouto/hupl/upload/UploadService.java
+++ b/app/src/main/java/eu/imouto/hupl/upload/UploadService.java
@@ -85,7 +85,8 @@ public class UploadService extends Service implements UploadProgressReceiver
             e.uploader = intent.getStringExtra("uploader");
             e.compress = intent.getBooleanExtra("compress", false);
             Uri uri = intent.getParcelableExtra("uri");
-            e.file = UriResolver.uriToFile(this, uri);
+            String text = intent.getStringExtra("text");
+            e.file = UriResolver.uriToFile(this, uri, text);
             if (e.file == null)
                 return START_STICKY; //TODO: display an error or something
 

--- a/app/src/main/java/eu/imouto/hupl/util/UriResolver.java
+++ b/app/src/main/java/eu/imouto/hupl/util/UriResolver.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.provider.OpenableColumns;
 import android.webkit.MimeTypeMap;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
@@ -16,46 +17,49 @@ public class UriResolver
 {
     private static final int RANDOM_FILENAME_LENGTH = 4;
 
-    public static FileToUpload uriToFile(Context context, Uri uri)
+    public static FileToUpload uriToFile(Context context, Uri uri, String text)
     {
-        ContentResolver res = context.getContentResolver();
-        InputStream inStream;
-
-        try
-        {
-            inStream = res.openInputStream(uri);
-        }
-        catch (FileNotFoundException ex)
-        {
-            return null;
-        }
-
-
-        //try to get the original filename and extension
-        String fileName = fileNameFromUri(context, uri);
-
-        //get the mime type
-        String mime = res.getType(uri);
-
-        //if the original filename can't be found,
-        //generate a randomised file name and try to find an extension using mime type
-        if (fileName == null)
-        {
-            MimeTypeMap mimeMap = MimeTypeMap.getSingleton();
-            String ext = mimeMap.getExtensionFromMimeType(mime);
-
-            //assume a generic binary format, if no mime type matches
-            if (ext == null)
-                ext = "bin";
-
-            fileName = RandomString.next(RANDOM_FILENAME_LENGTH)+"."+ext;
-        }
-
         FileToUpload file = new FileToUpload();
-        file.fileName = fileName;
-        file.stream = inStream;
-        file.mime = mime;
-        file.origUri = uri;
+
+        if (uri != null) {
+            ContentResolver res = context.getContentResolver();
+            InputStream inStream;
+
+            try {
+                inStream = res.openInputStream(uri);
+            } catch (FileNotFoundException ex) {
+                return null;
+            }
+
+
+            //try to get the original filename and extension
+            String fileName = fileNameFromUri(context, uri);
+
+            //get the mime type
+            String mime = res.getType(uri);
+
+            //if the original filename can't be found,
+            //generate a randomised file name and try to find an extension using mime type
+            if (fileName == null) {
+                MimeTypeMap mimeMap = MimeTypeMap.getSingleton();
+                String ext = mimeMap.getExtensionFromMimeType(mime);
+
+                //assume a generic binary format, if no mime type matches
+                if (ext == null)
+                    ext = "bin";
+
+                fileName = RandomString.next(RANDOM_FILENAME_LENGTH) + "." + ext;
+            }
+
+            file.fileName = fileName;
+            file.stream = inStream;
+            file.mime = mime;
+            file.origUri = uri;
+        } else {
+            file.fileName = "text.txt";
+            file.stream = new ByteArrayInputStream(text.getBytes());
+            file.mime = "text/plain";
+        }
 
         return file;
     }


### PR DESCRIPTION
Currently, when sharing a piece of text to Hupl (such as an URL), it will crash.

This PR fixes this by uploading any shared text as a `text/plain` file