### PR TITLE
Fix upload queue

### DIFF
--- a/app/src/main/java/eu/imouto/hupl/upload/UploadService.java
+++ b/app/src/main/java/eu/imouto/hupl/upload/UploadService.java
@@ -214,7 +214,9 @@ public class UploadService extends Service implements UploadProgressReceiver
 
         notification.success(fileLink);
         uploading = false;
-        stopFG();
+        if (uploadQueue.isEmpty()) {
+            stopFG();
+        }
         startUpload();
         updateQueueNotification();
     }


### PR DESCRIPTION
Currently, Hupl will stop foreground and re-start foreground after every file. 

This does not work on newer Android versions, because, once you stop foreground, service cannot put itself back to foreground again. So PR fixes this by not stopping foreground until queue is empty.